### PR TITLE
Added retry logic for flaky test cases

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -159,7 +159,8 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 60000
+        timeout: 60000,
+        retries: 2
     },
     //
     // =====


### PR DESCRIPTION
There are three levels , which you can add retry logic 
1. Global -> Which is implemented by this PR. 
2. At spec level , You have to add it under describe block **it.retries(number_of_times)**

If you think a particular spec file need more retires , then 2nd option is preferable. And also it overrides the global option if we have any

3. At test level, you have to add it under it block **it.retries(number_of_times)**

It will rerun the particular test case to the given number of times. It takes precedence than other two